### PR TITLE
fix: missing permission to allow mfa gql for guest

### DIFF
--- a/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-mfa.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.bundles.api.authorization-mfa.yml
@@ -3,6 +3,7 @@ mfa:
   grants:
   - api: "graphql.Mutation.mfa"
   - api: "graphql.Query.mfa"
+  - api: "graphql.MfaQuery"
   - api: "graphql.MfaMutation"
   - api: "graphql.MfaResponse"
   - api: "graphql.MfaFactorsMutation"


### PR DESCRIPTION
### Description

Provide missing .cfg for gql access to mfa api for guest