### PR TITLE
ci: Fix nightly tests

### DIFF
--- a/.github/workflows/nightly-RL.yml
+++ b/.github/workflows/nightly-RL.yml
@@ -14,6 +14,6 @@ jobs:
       module_id: jahia-multi-factor-authentication
       testrail_project: Jahia Multi-Factor Authentication Module
       pagerduty_incident_service: jahia-multi-factor-authentication-JahiaRL
-      provisioning_manifest: provisioning-manifest-build.yml
+      provisioning_manifest: provisioning-manifest-snapshot.yml
       artifact_prefix: mfa-nightly-rl
       module_branch: ${{ github.ref }}

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -3,4 +3,6 @@
     - 'mvn:org.jahia.modules/jahia-multi-factor-authentication-api'
     - 'mvn:org.jahia.modules/jahia-multi-factor-authentication-sample-ui'
     - 'mvn:org.jahia.test/jahia-multi-factor-authentication-test-module'
+  autoStart: true
+  uninstallPreviousVersion: true
 - include: 'provisioning.yml'


### PR DESCRIPTION
### Description
Fix the nightly tests (both release and snapshot):
- use `provisioning-manifest-snapshot.yml` for the _Nightly Test run (Jahia RL)_ to install the MFA module(s) before running the tests
- add the `autoStart: true` and `uninstallPreviousVersion: true` to properly install them

Tests:
- For Jahia RL: https://github.com/Jahia/jahia-multi-factor-authentication/actions/runs/17909466541
- For Jahia SN: https://github.com/Jahia/jahia-multi-factor-authentication/actions/runs/17909837718

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
