### PR TITLE
fix: Improve MFA API error handling and response consistency

### DIFF
--- a/api/src/main/java/org/jahia/modules/mfa/MfaSessionState.java
+++ b/api/src/main/java/org/jahia/modules/mfa/MfaSessionState.java
@@ -7,7 +7,7 @@ public enum MfaSessionState {
     NOT_STARTED("not_started"),
     IN_PROGRESS("in_progress"),
     COMPLETED("completed"),
-    FAILED("failed"); // TODO when should it be used?
+    FAILED("failed");
 
     private final String value;
 

--- a/api/src/main/java/org/jahia/modules/mfa/impl/gql/GqlMfaFactorsMutation.java
+++ b/api/src/main/java/org/jahia/modules/mfa/impl/gql/GqlMfaFactorsMutation.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * This GraphQL mutation class handles MFA factors specific operations.
- * It's exported and exposed, because it could be extended by other modules that would add their own factors.
+ * It's exported and exposed because it could be extended by other modules that would add their own factors.
  */
 @GraphQLName("MfaFactorsMutation")
 @GraphQLDescription("MFA state-modifying operations")
@@ -31,14 +31,8 @@ public class GqlMfaFactorsMutation {
     public GqlMfaResponse verifyEmailCodeFactor(@GraphQLName("code") String code, DataFetchingEnvironment environment) {
         try {
             HttpServletRequest httpServletRequest = ContextUtil.getHttpServletRequest(environment.getGraphQlContext());
-
             MfaSession session = mfaService.verifyFactor(EmailCodeFactorProvider.FACTOR_TYPE, httpServletRequest, code);
-            String error = session.getFactorVerificationError(EmailCodeFactorProvider.FACTOR_TYPE);
-            if (error != null) {
-                return GqlMfaUtils.createErrorResponse(error);
-            }
-
-            return GqlMfaUtils.createSessionStatusResponse(session);
+            return GqlMfaUtils.createFactorVerificationResponse(session, EmailCodeFactorProvider.FACTOR_TYPE);
         } catch (Exception e) {
             return GqlMfaUtils.createErrorResponse("Failed to verify email code: " + e.getMessage());
         }

--- a/api/src/main/java/org/jahia/modules/mfa/impl/gql/GqlMfaResponse.java
+++ b/api/src/main/java/org/jahia/modules/mfa/impl/gql/GqlMfaResponse.java
@@ -54,10 +54,6 @@ public class GqlMfaResponse {
         return sessionState;
     }
 
-    public void setSessionState(String sessionState) {
-        this.sessionState = sessionState;
-    }
-
     public void setSessionState(MfaSessionState sessionState) {
         this.sessionState = sessionState.getValue();
     }

--- a/api/src/main/java/org/jahia/modules/mfa/impl/gql/GqlMfaUtils.java
+++ b/api/src/main/java/org/jahia/modules/mfa/impl/gql/GqlMfaUtils.java
@@ -1,8 +1,10 @@
 package org.jahia.modules.mfa.impl.gql;
 
 import org.jahia.modules.mfa.MfaSession;
+import org.jahia.modules.mfa.MfaSessionState;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class GqlMfaUtils {
@@ -11,30 +13,101 @@ public class GqlMfaUtils {
         // helper class
     }
 
-    // Helper methods to reduce duplication
-    public static GqlMfaResponse createSuccessResponse(MfaSession session) {
-        GqlMfaResponse response = new GqlMfaResponse();
-        response.setSuccess(true);
-        response.setSessionState(session.getState());
+
+    /**
+     * Creates a GraphQL MFA response for an initiate operation.
+     * The success status of the response is determined by whether the MFA session state
+     * is equal to {@code MfaSessionState.IN_PROGRESS}.
+     *
+     * @param session the MFA session containing the current state, required,
+     *                and completed factors
+     * @return a {@code GqlMfaResponse} containing the required factors,
+     * completed factors, session state, and success status
+     */
+
+    public static GqlMfaResponse createInitiateResponse(MfaSession session) {
+        GqlMfaResponse response = createResponse(session);
+        response.setSuccess(MfaSessionState.IN_PROGRESS.equals(session.getState()));
         return response;
     }
 
-    public static GqlMfaResponse createSessionStatusResponse(MfaSession session) {
-        GqlMfaResponse response = createSuccessResponse(session);
 
-        List<String> preparedFactors = new ArrayList<>(session.getPreparedFactors());
-        response.setRequiredFactors(preparedFactors);
-
-        List<String> completedFactors = new ArrayList<>(session.getCompletedFactors());
-        response.setCompletedFactors(completedFactors);
-
+    /**
+     * Creates a GraphQL Multi-Factor Authentication (MFA) response for a factor preparation operation.
+     * The success status of the response is determined based on the current state of the MFA session
+     * and any preparation errors for the specified factor.
+     *
+     * @param session    the MFA session containing the state and factor information
+     * @param factorType the type of MFA factor being prepared
+     * @return a {@code GqlMfaResponse} representing the result of the factor preparation operation,
+     * including success status and error details if applicable
+     */
+    public static GqlMfaResponse createFactorPreparationResponse(MfaSession session, String factorType) {
+        GqlMfaResponse response = createResponse(session);
+        String error = session.getFactorPreparationError(factorType);
+        if (MfaSessionState.FAILED.equals(session.getState()) || error != null) {
+            response.setSuccess(false);
+            response.setError(error);
+        } else {
+            // assume the operation successfully completes
+            response.setSuccess(true);
+        }
         return response;
     }
 
+    /**
+     * Creates a GraphQL Multi-Factor Authentication (MFA) response for a factor verification operation.
+     * The success status of the response is determined based on the current state of the MFA session
+     * and any verification errors for the specified factor.
+     *
+     * @param session    the MFA session containing the current state and factor verification information
+     * @param factorType the type of MFA factor being verified
+     * @return a {@code GqlMfaResponse} representing the result of the factor verification operation,
+     * including success status and error details if applicable
+     */
+    public static GqlMfaResponse createFactorVerificationResponse(MfaSession session, String factorType) {
+        GqlMfaResponse response = createResponse(session);
+        String error = session.getFactorVerificationError(factorType);
+        if (MfaSessionState.FAILED.equals(session.getState()) || error != null) {
+            response.setSuccess(false);
+            if (factorType != null) {
+                response.setError(error);
+            }
+        } else {
+            // assume the operation successfully completes
+            response.setSuccess(true);
+        }
+        return response;
+    }
+
+
+    /**
+     * Creates a GraphQL Multi-Factor Authentication (MFA) response representing
+     * an error state, useful when an unexpected error occurs. This method sets the response as unsuccessful and includes
+     * the provided error message.
+     *
+     * @param error the error message to include in the response
+     * @return a {@code GqlMfaResponse} containing the error message, an unsuccessful
+     * status, an empty list of required and completed factors, and a session state
+     * of {@code MfaSessionState.FAILED}
+     */
     public static GqlMfaResponse createErrorResponse(String error) {
         GqlMfaResponse response = new GqlMfaResponse();
+        response.setRequiredFactors(Collections.emptyList());
+        response.setCompletedFactors(Collections.emptyList());
         response.setSuccess(false);
         response.setError(error);
+        response.setSessionState(MfaSessionState.FAILED);
+        return response;
+    }
+
+    private static GqlMfaResponse createResponse(MfaSession session) {
+        GqlMfaResponse response = new GqlMfaResponse();
+        List<String> preparedFactors = new ArrayList<>(session.getPreparedFactors());
+        response.setRequiredFactors(preparedFactors);
+        List<String> completedFactors = new ArrayList<>(session.getCompletedFactors());
+        response.setCompletedFactors(completedFactors);
+        response.setSessionState(session.getState());
         return response;
     }
 }

--- a/tests/cypress/e2e/graphQL.emailFactor.cy.ts
+++ b/tests/cypress/e2e/graphQL.emailFactor.cy.ts
@@ -137,12 +137,12 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
         initiate(TEST_USER_NO_EMAIL.username(), TEST_USER_NO_EMAIL.password);
 
         cy.log('2- prepare');
-        prepare('email_code', 'User does not have an email address configured');
+        prepare('email_code', 'email_code', 'User does not have an email address configured');
     });
 
     it('Should throw an error when preparing without initiating the factor', () => {
         cy.log('2- prepare');
-        prepare('email_code', 'Failed to prepare factor: No active MFA session found');
+        prepare('email_code', 'email_code', 'Failed to prepare factor: No active MFA session found');
     });
 
     it('Should be locked when multiple wrong verification codes are entered in a row', () => {

--- a/tests/cypress/e2e/graphQL.errors.cy.ts
+++ b/tests/cypress/e2e/graphQL.errors.cy.ts
@@ -52,7 +52,7 @@ describe('Error scenarios common to all factors', () => {
         initiate(usr, pwd);
 
         cy.log('2- prepare');
-        prepare('unknown_factor', 'Factor type not supported: unknown_factor');
+        prepare('unknown_factor', 'email_code', 'Factor type not supported: unknown_factor');
     });
 
     it('Should throw an error when a factor is requested twice, then should pass after the timeout', () => {
@@ -63,7 +63,7 @@ describe('Error scenarios common to all factors', () => {
         prepare('email_code');
 
         cy.log('3- prepare again');
-        prepare('email_code', `The factor email_code already generated for user ${usr}`);
+        prepare('email_code', 'email_code', `The factor email_code already generated for user ${usr}`);
 
         cy.log('4- wait for end of timeout');
         // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/tests/cypress/e2e/utils/emailFactor.ts
+++ b/tests/cypress/e2e/utils/emailFactor.ts
@@ -51,18 +51,17 @@ export function verifyEmailCodeFactor(code: string, expectedError: string = unde
         if (expectedError) {
             expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.success).false;
             expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.error).eq(expectedError);
-            // TODO is that correct: ?
-            expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.sessionState).to.be.null;
-            expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.requiredFactors).to.be.null;
-            expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.completedFactors).to.be.null;
+            expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.sessionState).eq('in_progress');
+            expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.completedFactors).to.be.a('array').and.be.empty;
         } else {
             expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.success).true;
             expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.sessionState).eq('completed');
-            expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.requiredFactors).a('array').and.have.length(1);
-            expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.requiredFactors[0]).eq('email_code');
             expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.completedFactors).to.be.a('array').and.have.length(1);
             expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.completedFactors[0]).eq('email_code');
         }
+
+        expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.requiredFactors).a('array').and.have.length(1);
+        expect(response?.data?.mfa?.factors?.verifyEmailCodeFactor?.requiredFactors[0]).eq('email_code');
     });
 }
 


### PR DESCRIPTION
### Description
Improve the MFA GraphQL APIs error handling to provide more consistent error handling and response structures.
`GqlMfaUtils` has been refactored to ensure all responses include `requiredFactors`, `completedFactors`, and `sessionState`, even on errors.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
