### PR TITLE
ci: use latest JavaScript module for nightly tests

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,5 +1,9 @@
 - addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaPublicSnapshots'
 - installBundle:
+    - 'mvn:org.jahia.modules/javascript-modules-engine' # the MFA UI module is a JavaScript module
+  autoStart: true
+  uninstallPreviousVersion: true
+- installBundle:
     - 'mvn:org.jahia.modules/jahia-multi-factor-authentication-api'
     - 'mvn:org.jahia.test/jahia-multi-factor-authentication-test-module'
     # LATEST is a Maven special "metaversion" that will always point to the latest version of the module, including snapshots


### PR DESCRIPTION
### Description

[The nightly tests](https://github.com/Jahia/jahia-multi-factor-authentication/actions/workflows/nightly-RL.yml) with the latest Jahia release are currently failing as an old JavaScript Module engine (version 0.3.0 as of today) is shipped with the latest release.
Update the provisioning file for the nightly tests to use the latest JavaScript Module engine.

Run in progress to validate the fix: https://github.com/Jahia/jahia-multi-factor-authentication/actions/runs/18337735159

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
