### PR TITLE
ci(nightly): Add missing custom mail code template module

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -6,6 +6,7 @@
 - installBundle:
     - 'mvn:org.jahia.modules/jahia-multi-factor-authentication-api'
     - 'mvn:org.jahia.test/jahia-multi-factor-authentication-test-module'
+    - 'mvn:org.jahia.test/jahia-multi-factor-authentication-test-module-custom-mail-code-template'
     # LATEST is a Maven special "metaversion" that will always point to the latest version of the module, including snapshots
     - 'js:mvn:org.jahia.modules/jahia-multi-factor-authentication-ui/LATEST/tgz'
   autoStart: true


### PR DESCRIPTION
### Description
Add the installation of _org.jahia.test/jahia-multi-factor-authentication-test-module-custom-mail-code-template_ in the provisioning file used by the nightly tests, that was added in https://github.com/Jahia/jahia-multi-factor-authentication/pull/47.

Run to validate the fix: https://github.com/Jahia/jahia-multi-factor-authentication/actions/runs/18586900436/job/52992759767 ✅ .


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
