### PR TITLE
fix: do not fail session when rate limit is exceeded

### DIFF
--- a/api/src/main/java/org/jahia/modules/mfa/MfaPreparationRateLimitException.java
+++ b/api/src/main/java/org/jahia/modules/mfa/MfaPreparationRateLimitException.java
@@ -1,0 +1,14 @@
+package org.jahia.modules.mfa;
+
+import org.jahia.services.content.decorator.JCRUserNode;
+
+/**
+ * Exception thrown when the MFA preparation rate limit is exceeded.<br>
+ *
+ * Unlike other exceptions that may occur during the preparation of an MFA factor, {@link MfaPreparationRateLimitException} does not mark the MFA session as failed.
+ */
+public class MfaPreparationRateLimitException extends MfaException {
+    public MfaPreparationRateLimitException(String factorType, JCRUserNode user, long nextRetryInSeconds) {
+        super("prepare.rate_limit_exceeded", "nextRetryInSeconds", String.valueOf(nextRetryInSeconds), "factorType", factorType, "user", user.getName());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Jahia/jahia-multi-factor-authentication/issues/23.
### Description

Dot not mark the MFA session as "preparation failed" when trying to resend a new verification code before `factorStartRateLimitSeconds` is elapsed.

Introduce a dedicated exception for this scenario to differentiate it from the rest of the exceptions that may occur during the preparation of an MFA factor.

### Checklist

#### Tests
- [x] I've provided Unit and/or Integration Tests

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
