### PR TITLE
fix: Do not escape URL in the redirect message

### DIFF
--- a/tests/cypress/e2e/ui.cy.ts
+++ b/tests/cypress/e2e/ui.cy.ts
@@ -181,6 +181,7 @@ describe('Tests for the UI module', () => {
             );
         });
     });
+
     it('Should redirect to the provided redirect page', () => {
         cy.visit(`/sites/${SITE_KEY}/${LOGIN_PAGE_NAME}.html?redirect=%2Fcms%2Frender%2Flive%2Fen%2Fsites%2F${SITE_KEY}%2Fhome.html%3Fparam%3Dtest`);
         enterCredential(username, password);
@@ -188,6 +189,7 @@ describe('Tests for the UI module', () => {
         getVerificationCode(email).then(code => {
             cy.log('Verification code received by email: ' + code);
             enterVerificationCode(code);
+            cy.get('[data-testid="success-message"]').should('contain', 'Redirect URL: /cms/render/live/en/sites/sample-ui/home.html?param=test');
             cy.url({timeout: 15000}).should('contain', `/cms/render/live/en/sites/${SITE_KEY}/home.html`);
             cy.url({timeout: 15000}).should('match', /\?param=test$/);
             cy.url({timeout: 15000}).should('not.contain', `${LOGIN_PAGE_NAME}.html`);

--- a/ui/src/components/Authentication/Authentication.client.tsx
+++ b/ui/src/components/Authentication/Authentication.client.tsx
@@ -77,6 +77,7 @@ export default function ({ apiRoot, content }: { apiRoot: string; content: Props
                   values={{
                     redirectUrl: redirectUrl,
                   }}
+                  shouldUnescape
                 />
               </div>
               <div style={{ fontSize: "16px", color: "#333", marginBottom: "10px" }}>


### PR DESCRIPTION
Fixes https://github.com/Jahia/jahia-multi-factor-authentication/pull/54#issuecomment-3452566707.
### Description
Do not escape URL displayed in the message shown before redirecting the user.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="532" height="478" alt="image" src="https://github.com/user-attachments/assets/a3ca9b33-9e07-465a-a889-82e230aeed37" />
 <td><img width="532" height="478" alt="image" src="https://github.com/user-attachments/assets/c1f0af78-fc66-4c2b-bfab-e928fdd79d7e" />
</table>

### Checklist
#### Tests
- [x] I've provided Unit and/or Integration Tests

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
