### PR TITLE
fix: should not able to use a code received before suspension

### DIFF
--- a/api/src/main/java/org/jahia/modules/mfa/impl/factors/EmailCodeFactorProvider.java
+++ b/api/src/main/java/org/jahia/modules/mfa/impl/factors/EmailCodeFactorProvider.java
@@ -113,7 +113,7 @@ public class EmailCodeFactorProvider implements MfaFactorProvider {
             throw new MfaException("factor.email_code.verification_code_required");
         }
         PreparationResult preparationResult = (PreparationResult) verificationContext.getPreparationResult();
-        String storedCode = preparationResult.getCode();
+        String storedCode = preparationResult != null ? preparationResult.getCode() : null;
         if (StringUtils.isEmpty(storedCode)) {
             throw new MfaException("factor.email_code.missing_prepared_code");
         }

--- a/tests/cypress/e2e/graphQL.emailFactor.cy.ts
+++ b/tests/cypress/e2e/graphQL.emailFactor.cy.ts
@@ -175,7 +175,7 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
         });
     });
 
-    it('Should be locked when multiple wrong verification codes are entered in a row', () => {
+    it.only('Should be suspended when multiple wrong verification codes are entered in a row', () => {
         cy.log('0- installing the MFA configuration');
         // Config is:
         // maxAuthFailuresBeforeLock: 3
@@ -216,8 +216,8 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
             // Wait until the suspension expires
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(6000);
-            verifyEmailCodeFactor(code);
-            assertIsLoggedIn(TEST_USER.username());
+            // The (valid) code obtained before being suspended can't be used anymore
+            verifyEmailCodeFactorAndExpectError(code, 'factor.email_code.missing_prepared_code');
         });
     });
 


### PR DESCRIPTION
Fixes https://github.com/Jahia/jahia-multi-factor-authentication/issues/16.

### Description
If a user receives a valid code and then gets suspended, that code should not be valid anymore, as the user should start the MFA process from the start at this point.

#### Change

As we check if a user is suspended by checking the JCR repository (the `mfa:suspendedUser` mixin), we can safely delete the caches entries for that user and remove the preparation result (containing the code) from their session.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
