### PR TITLE
feat: Include suspension duration in message

### DIFF
--- a/api/src/main/java/org/jahia/modules/mfa/MfaException.java
+++ b/api/src/main/java/org/jahia/modules/mfa/MfaException.java
@@ -20,21 +20,15 @@ public class MfaException extends Exception {
     }
 
     public MfaException(String code, String argumentKey, String argumentValue) {
-        super();
-        this.code = code;
-        this.arguments = Map.of(argumentKey, argumentValue);
+        this(code, Map.of(argumentKey, argumentValue));
     }
 
     public MfaException(String code, String argument1Key, String argument1Value, String argument2Key, String argument2Value) {
-        super();
-        this.code = code;
-        this.arguments = Map.of(argument1Key, argument1Value, argument2Key, argument2Value);
+        this(code, Map.of(argument1Key, argument1Value, argument2Key, argument2Value));
     }
 
     public MfaException(String code, String argument1Key, String argument1Value, String argument2Key, String argument2Value, String argument3Key, String argument3Value) {
-        super();
-        this.code = code;
-        this.arguments = Map.of(argument1Key, argument1Value, argument2Key, argument2Value, argument3Key, argument3Value);
+        this(code, Map.of(argument1Key, argument1Value, argument2Key, argument2Value, argument3Key, argument3Value));
     }
 
     public String getCode() {

--- a/api/src/main/java/org/jahia/modules/mfa/impl/MfaServiceImpl.java
+++ b/api/src/main/java/org/jahia/modules/mfa/impl/MfaServiceImpl.java
@@ -260,15 +260,21 @@ public class MfaServiceImpl implements MfaService {
         validateUserNotSuspended(user);
         if (hasReachedAuthFailuresCountLimit(user.getPath(), provider)) {
             suspendUser(request, user, provider);
-            throw new MfaException("suspended_user");
+            throwSuspendedUserException();
         }
     }
 
     private void validateUserNotSuspended(JCRUserNode user) throws MfaException {
         if (isUserSuspended(user.getPath())) {
             logger.warn("User {} is suspended", user.getPath());
-            throw new MfaException("suspended_user");
+            throwSuspendedUserException();
         }
+    }
+
+    private void throwSuspendedUserException() throws MfaException {
+        // convert and round up suspension in seconds to hours
+        int suspensionDurationInHours = (int) Math.ceil(mfaConfigurationService.getUserTemporarySuspensionSeconds() / 3600.0);
+        throw new MfaException("suspended_user", "suspensionDurationInHours", Integer.toString(suspensionDurationInHours));
     }
 
     private boolean isUserSuspended(String userPath) throws MfaException {

--- a/tests/cypress/e2e/graphQL.emailFactor.cy.ts
+++ b/tests/cypress/e2e/graphQL.emailFactor.cy.ts
@@ -175,7 +175,7 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
         });
     });
 
-    it.only('Should be suspended when multiple wrong verification codes are entered in a row', () => {
+    it('Should be suspended when multiple wrong verification codes are entered in a row', () => {
         cy.log('0- installing the MFA configuration');
         // Config is:
         // maxAuthFailuresBeforeLock: 3
@@ -209,10 +209,14 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
             });
             wrongCode = generateWrongCode(wrongCode);
             cy.log('4th attempt: ' + wrongCode);
-            verifyEmailCodeFactorAndExpectError(wrongCode, 'suspended_user');
+            verifyEmailCodeFactorAndExpectError(wrongCode, 'suspended_user', {
+                suspensionDurationInHours: value => expect(value).to.eq('1') // 6 seconds rounded up to 1 hour
+            });
             assertIsSuspended(TEST_USER.username());
             cy.log('Even the valid code is not accepted: ' + code);
-            verifyEmailCodeFactorAndExpectError(wrongCode, 'suspended_user');
+            verifyEmailCodeFactorAndExpectError(wrongCode, 'suspended_user', {
+                suspensionDurationInHours: value => expect(value).to.eq('1') // 6 seconds rounded up to 1 hour
+            });
             // Wait until the suspension expires
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(6000);

--- a/tests/cypress/e2e/graphQL.errors.cy.ts
+++ b/tests/cypress/e2e/graphQL.errors.cy.ts
@@ -74,13 +74,17 @@ describe('Error scenarios common to all factors', () => {
     it('Should throw an error when a suspended user tries to initiate the MFA flow', () => {
         suspendUser(usr, pwd, email);
 
-        initiateAndExpectError(usr, pwd, 'suspended_user');
+        initiateAndExpectError(usr, pwd, 'suspended_user', {
+            suspensionDurationInHours: value => expect(value).to.eq('1') // 6 seconds rounded up to 1 hour
+        });
     });
 
     it('Should throw an error when a suspended user tries to prepare a factor', () => {
         suspendUser(usr, pwd, email);
 
-        prepareEmailCodeFactorAndExpectError('suspended_user');
+        prepareEmailCodeFactorAndExpectError('suspended_user', {
+            suspensionDurationInHours: value => expect(value).to.eq('1') // 6 seconds rounded up to 1 hour
+        });
     });
 
     /**
@@ -117,7 +121,9 @@ describe('Error scenarios common to all factors', () => {
 
             // Final attempt should trigger suspension
             wrongCode = generateWrongCode(wrongCode);
-            verifyEmailCodeFactorAndExpectError(wrongCode, 'suspended_user');
+            verifyEmailCodeFactorAndExpectError(wrongCode, 'suspended_user', {
+                suspensionDurationInHours: value => expect(value).to.eq('1') // 6 seconds rounded up to 1 hour
+            });
         });
     };
 });

--- a/tests/cypress/e2e/utils/i18n.ts
+++ b/tests/cypress/e2e/utils/i18n.ts
@@ -25,7 +25,7 @@ export const I18N = {
             'no_active_session': 'No active MFA session found',
             'authentication_failed': 'Invalid username or password',
             'verification_failed': 'Verification failed',
-            'suspended_user': 'You have been suspended after too many failed attempts',
+            'suspended_user': 'Your account is temporarily locked for {{suspensionDurationInHours}} hours.',
             'failed_to_check_if_user_suspended': 'Failed to check if the user is suspended',
             'failed_to_mark_user_as_suspended': 'Failed to mark user as suspended',
             'factor_type_not_supported': 'Factor {{factorType}} not supported',

--- a/tests/cypress/fixtures/mfa-configuration/sample-ui-long-suspension.yml
+++ b/tests/cypress/fixtures/mfa-configuration/sample-ui-long-suspension.yml
@@ -1,0 +1,8 @@
+- editConfiguration: "org.jahia.modules.mfa"
+  properties:
+    enabled: "true"
+    loginUrl: "/sites/sample-ui/myLoginPage.html"
+    enabledFactors: "email_code"
+    factorStartRateLimitSeconds: "3"
+    maxAuthFailuresBeforeLock: "3"
+    userTemporarySuspensionSeconds: "97200" # 27 hours = 60 * 60 * 27

--- a/ui/settings/locales/en.json
+++ b/ui/settings/locales/en.json
@@ -4,7 +4,7 @@
   "no_active_session": "No active MFA session found",
   "authentication_failed": "Invalid username or password",
   "verification_failed": "Verification failed",
-  "suspended_user": "You have been suspended after too many failed attempts",
+  "suspended_user": "Your account is temporarily locked for {{suspensionDurationInHours}} hours.",
   "failed_to_check_if_user_suspended": "Failed to check if the user is suspended",
   "failed_to_mark_user_as_suspended": "Failed to mark user as suspended",
   "factor_type_not_supported": "Factor {{factorType}} not supported",


### PR DESCRIPTION
### Description
Include the suspension duration in the error message when a user gets suspended.
_NB: the suspension duration is specified in seconds but displayed in hours to the end-users (after being rounded up)._

### Checklist

#### Tests
- [x] I've provided Unit and/or Integration Tests

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
