### PR TITLE
refactor: Introduce base structure (success & error) for services return types

### DIFF
--- a/ui/src/services/clear.tsx
+++ b/ui/src/services/clear.tsx
@@ -1,13 +1,7 @@
-interface ClearResultSuccess {
-  success: true;
-}
-interface ClearResultError {
-  success: false;
-  error: {
-    code: string;
-    arguments: Array<{ name: string; value: string }>;
-  };
-}
+import type { BaseError, BaseSuccess } from "./common";
+
+type ClearResultSuccess = BaseSuccess;
+type ClearResultError = BaseError;
 export type ClearResult = ClearResultSuccess | ClearResultError;
 
 export default async function clear(apiRoot: string): Promise<ClearResult> {

--- a/ui/src/services/common.tsx
+++ b/ui/src/services/common.tsx
@@ -1,0 +1,19 @@
+/**
+ * Base structure for the GraphQL APIs on successful responses.
+ */
+export interface BaseSuccess {
+  success: true;
+}
+
+/**
+ * Base structure for the GraphQL APIs on error response.
+ * The error contains a `code` and an optional array of `arguments` (with a `name` and `value`)
+ */
+
+export interface BaseError {
+  success: false;
+  error: {
+    code: string;
+    arguments: Array<{ name: string; value: string }>;
+  };
+}

--- a/ui/src/services/login.tsx
+++ b/ui/src/services/login.tsx
@@ -1,13 +1,7 @@
-interface LoginResultSuccess {
-  success: true;
-}
-interface LoginResultError {
-  success: false;
-  error: {
-    code: string;
-    arguments: Array<{ name: string; value: string }>;
-  };
-}
+import type { BaseError, BaseSuccess } from "./common";
+
+type LoginResultSuccess = BaseSuccess;
+type LoginResultError = BaseError;
 export type LoginResult = LoginResultSuccess | LoginResultError;
 
 export default async function login(

--- a/ui/src/services/prepareEmailFactor.tsx
+++ b/ui/src/services/prepareEmailFactor.tsx
@@ -1,14 +1,9 @@
-interface PrepareEmailFactorResultSuccess {
-  success: true;
+import type { BaseError, BaseSuccess } from "./common";
+
+interface PrepareEmailFactorResultSuccess extends BaseSuccess {
   maskedEmail: string;
 }
-interface PrepareEmailFactorResultError {
-  success: false;
-  error: {
-    code: string;
-    arguments: Array<{ name: string; value: string }>;
-  };
-}
+type PrepareEmailFactorResultError = BaseError;
 export type PrepareEmailFactorResult =
   | PrepareEmailFactorResultSuccess
   | PrepareEmailFactorResultError;

--- a/ui/src/services/verifyEmailCodeFactor.tsx
+++ b/ui/src/services/verifyEmailCodeFactor.tsx
@@ -1,13 +1,7 @@
-interface VerifyEmailFactorResultSuccess {
-  success: true;
-}
-interface VerifyEmailFactorResultError {
-  success: false;
-  error: {
-    code: string;
-    arguments: Array<{ name: string; value: string }>;
-  };
-}
+import type { BaseError, BaseSuccess } from "./common";
+
+type VerifyEmailFactorResultSuccess = BaseSuccess;
+type VerifyEmailFactorResultError = BaseError;
 export type VerifyEmailFactorResult = VerifyEmailFactorResultSuccess | VerifyEmailFactorResultError;
 
 export default async function verifyEmailCodeFactor(


### PR DESCRIPTION
~Depends on https://github.com/Jahia/jahia-multi-factor-authentication/pull/66.~
### Description
Refactor the return types of the services interacting with the GraphQL APIs, to introduce base structure for both success and error responses.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
