### PR TITLE
test: Add browsing test

### DIFF
--- a/tests/cypress/e2e/browsing.cy.ts
+++ b/tests/cypress/e2e/browsing.cy.ts
@@ -1,0 +1,78 @@
+import {addNode, deleteSite, deleteUser, publishAndWaitJobEnding, revokeRoles} from '@jahia/cypress';
+import {faker} from '@faker-js/faker';
+import {
+    createSiteWithLoginPage,
+    createUserForMFA,
+    deleteAllEmails,
+    installMFAConfig
+} from './utils';
+
+const SITE_KEY = 'sample-browsing';
+const PAGE_NAME = 'protected';
+
+describe('Browsing Tests', () => {
+    let username: string;
+    let password: string;
+    let email: string;
+
+    before(() => {
+        createSiteWithLoginPage(SITE_KEY);
+    });
+
+    beforeEach(() => {
+        installMFAConfig('sample-ui.yml'); // Tests might change the MFA config
+        username = faker.internet.username();
+        password = faker.internet.password();
+        email = faker.internet.email();
+        createUserForMFA(username, password, email);
+        deleteAllEmails(); // Sanity cleanup
+    });
+
+    afterEach(() => {
+        deleteUser(username);
+        deleteAllEmails();
+    });
+
+    after(() => {
+        deleteSite(SITE_KEY);
+    });
+
+    it('Should return a 404 on page when MFA is deployed', () => {
+        const properties = [
+            {name: 'jcr:title', value: 'Protected page (EN)', language: 'en'},
+            {name: 'j:templateName', value: 'simple', language: 'en'}
+        ];
+
+        // Create and publish the protected page
+        addNode({
+            parentPathOrId: `/sites/${SITE_KEY}`,
+            name: PAGE_NAME,
+            primaryNodeType: 'jnt:page',
+            properties: properties
+        });
+        publishAndWaitJobEnding(`/sites/${SITE_KEY}`, ['en']);
+
+        const pageUrl = `/sites/${SITE_KEY}/${PAGE_NAME}.html`;
+
+        // Verify page is accessible (200) before revoking permissions
+        cy.logout();
+        cy.request(pageUrl).then(response => {
+            expect(response.status).to.eq(200);
+            expect(response.headers['content-type']).to.include('text/html');
+        });
+
+        // Revoke guest access and republish
+        revokeRoles(`/sites/${SITE_KEY}/${PAGE_NAME}`, ['reader'], 'guest', 'USER');
+        publishAndWaitJobEnding(`/sites/${SITE_KEY}`, ['en']);
+
+        // Verify page returns 404 after permissions revoked
+        cy.logout();
+        cy.request({
+            url: pageUrl,
+            failOnStatusCode: false
+        }).then(response => {
+            expect(response.status).to.eq(404);
+            expect(response.body).to.not.include('Protected page');
+        });
+    });
+});


### PR DESCRIPTION
fixes [#45](https://github.com/Jahia/jahia-multi-factor-authentication/issues/45)
### Description
Add a simple browsing test to ensure a page without read permission lead to a 404 as expected.  

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
