### PR TITLE
ci(nightly): Missing custom factor test module in provisioning

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -6,6 +6,7 @@
 - installBundle:
     - 'mvn:org.jahia.modules/jahia-multi-factor-authentication-api'
     - 'mvn:org.jahia.test/jahia-multi-factor-authentication-test-module'
+    - 'mvn:org.jahia.test/jahia-multi-factor-authentication-test-module-custom-factor'
     - 'mvn:org.jahia.test/jahia-multi-factor-authentication-test-module-custom-mail-code-template'
     # LATEST is a Maven special "metaversion" that will always point to the latest version of the module, including snapshots
     - 'js:mvn:org.jahia.modules/jahia-multi-factor-authentication-ui/LATEST/tgz'


### PR DESCRIPTION
### Description
Add the missing test module (_jahia-multi-factor-authentication-test-module-custom-factor_ ) that was added in https://github.com/Jahia/jahia-multi-factor-authentication/pull/76 but not added in the provisioning file for the nightly tests.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
