### PR TITLE
test: add edge-case validation

### DIFF
--- a/tests/cypress/e2e/ui.mfa.cy.ts
+++ b/tests/cypress/e2e/ui.mfa.cy.ts
@@ -131,7 +131,7 @@ describe('Tests for the UI module', () => {
         });
     });
 
-    it.only('Should be authenticated when EMAIL_FACTOR becomes disabled in the middle of the flow', () => {
+    it('Should be authenticated when EMAIL_FACTOR becomes disabled in the middle of the flow', () => {
         LoginStep.triggerRedirect(SITE_KEY);
 
         // Validate UI content on the login step


### PR DESCRIPTION
Added an edge-case validation when user starts auth flow when `email_factor` is `enabled` initially, but becomes `disabled` once user passes usr/pwd step.
User still should be able to complete flow entering received code (even though email_code factor became disabled at this point)
