### PR TITLE
build: Use Jahia Plugin inherited from the parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     </modules>
 
     <properties>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
         <jahia-bom.version>8.2.3.0-SNAPSHOT</jahia-bom.version> <!-- should match ${project.parent.version} -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>


### PR DESCRIPTION
### Description
Do not override the Jahia Plugin version ans simply inherit the one defined in the pom ([version 6.14](https://github.com/Jahia/jahia-private/blob/master/jahia-parent/pom.xml#L197) as of today).


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
