### PR TITLE
fix(email): Switch to PNG format for the Jahia Cloud logo

### DIFF
--- a/api/src/main/resources/jnt_template/html/template.mailCodeView.jsp
+++ b/api/src/main/resources/jnt_template/html/template.mailCodeView.jsp
@@ -57,9 +57,9 @@
                                         <%-- it is not possible to use the usual syntax, for instance:
                                         <img src="<c:url value="${url.server}${url.context}${url.currentModule}/path/to/your/image.png"/>">
                                          --%>
-                                        <img src="https://jahia.cloud/modules/dx-jelastic-template/media/jahia-cloud-logo.svg"
+                                        <img src="https://jahia.cloud/modules/dx-jelastic-template/media/jahia-cloud-logo-small.png"
                                              alt="Jahia"
-                                             width="130"
+                                             width="155"
                                              height="70"
                                              style="display: block; border: 0; outline: none; text-decoration: none;" />
                                     </a>


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/105.
**⚠️ Requires https://github.com/Jahia/jahia-cloud-modules/pull/1097 to be merged and deployed first ⚠️** 

### Description

Use the PNG image from https://github.com/Jahia/jahia-cloud-modules/pull/1097 to maximise compatibility with email clients.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
