### PR TITLE
chore: Remove 'enabled' configuration flag

### DIFF
--- a/api/src/main/java/org/jahia/modules/upa/mfa/impl/MfaConfigurationService.java
+++ b/api/src/main/java/org/jahia/modules/upa/mfa/impl/MfaConfigurationService.java
@@ -48,9 +48,6 @@ public class MfaConfigurationService {
         @AttributeDefinition(name = "%loginUrl", description = "%loginUrlDesc")
         String loginUrl();
 
-        @AttributeDefinition(name = "%enabled", description = "%enabledDesc", defaultValue = "false")
-        boolean enabled();
-
         @AttributeDefinition(name = "%enabledFactors", description = "%enabledFactorsDesc")
         String[] enabledFactors() default {"email_code"};
 
@@ -86,24 +83,17 @@ public class MfaConfigurationService {
     @Activate
     public void activate(Config config) {
         this.config = config;
-        logger.info("MFA Service activated with enabled={}", config.enabled());
+        logger.info("MFA Service activated");
     }
 
     @Modified
     public void modified(Config config) {
         this.config = config;
-        logger.info("MFA Service configuration modified with enabled={}", config.enabled());
+        logger.info("MFA Service configuration modified");
     }
 
     public String getLoginUrl() {
-        return config.enabled() ? config.loginUrl() : null;
-    }
-
-    /**
-     * Checks if MFA is enabled in the system configuration.
-     */
-    public boolean isEnabled() {
-        return config.enabled();
+        return config.loginUrl();
     }
 
     public String[] getEnabledFactors() {

--- a/api/src/main/java/org/jahia/modules/upa/mfa/impl/gql/Query.java
+++ b/api/src/main/java/org/jahia/modules/upa/mfa/impl/gql/Query.java
@@ -24,7 +24,6 @@ import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
 import org.jahia.modules.upa.mfa.MfaService;
 import org.jahia.modules.upa.mfa.MfaSession;
 import org.jahia.modules.upa.mfa.gql.Session;
-import org.jahia.modules.upa.mfa.impl.MfaConfigurationService;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -35,7 +34,6 @@ import java.util.List;
 public class Query {
 
     private MfaService mfaService;
-    private MfaConfigurationService mfaConfigurationService;
 
     @Inject
     @GraphQLOsgiService
@@ -43,18 +41,6 @@ public class Query {
         this.mfaService = mfaService;
     }
 
-    @Inject
-    @GraphQLOsgiService
-    public void setMfaConfigurationService(MfaConfigurationService mfaConfigurationService) {
-        this.mfaConfigurationService = mfaConfigurationService;
-    }
-
-    @GraphQLField
-    @GraphQLName("mfaEnabled")
-    @GraphQLDescription("True if MFA feature is enabled by configuration")
-    public boolean enabled() {
-        return mfaConfigurationService.isEnabled();
-    }
 
     @GraphQLField
     @GraphQLName("mfaAvailableFactors")

--- a/api/src/main/resources/META-INF/configurations/org.jahia.modules.upa.mfa.cfg
+++ b/api/src/main/resources/META-INF/configurations/org.jahia.modules.upa.mfa.cfg
@@ -1,6 +1,5 @@
 # default configuration, can be edited
 
-enabled=false
 loginUrl=/sites/systemSite/login.html
 enabledFactors.0=email_code
 maxAuthFailuresBeforeLock=5

--- a/api/src/main/resources/OSGI-INF/l10n/mfa/config.properties
+++ b/api/src/main/resources/OSGI-INF/l10n/mfa/config.properties
@@ -1,7 +1,5 @@
 configName=Jahia MFA module configuration
 configDesc=Jahia MFA (Multi-Factor Authentication) module configuration. Once enabled and loginUrl configured, the module will display a login page that should contain some MFA login form components.
-enabled=Enabled
-enabledDesc=Should the MFA authentication be enabled?
 loginUrl=Url of the login page
 loginUrlDesc=Url of the login page that should contain some MFA login form components. (the page must be accessible without authentication)
 enabledFactors=Enabled Factors

--- a/tests/cypress/e2e/graphQL.emailFactor.cy.ts
+++ b/tests/cypress/e2e/graphQL.emailFactor.cy.ts
@@ -69,7 +69,6 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
 
     after(() => {
         [TEST_USER_NO_EMAIL, ...SPECIAL_USERS].forEach(user => deleteUser(user.username()));
-        installMFAConfig('disabled.yml');
     });
 
     /**

--- a/tests/cypress/fixtures/mfa-configuration/custom-factor.yml
+++ b/tests/cypress/fixtures/mfa-configuration/custom-factor.yml
@@ -1,6 +1,5 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/sample-ui/myLoginPage.html"
     enabledFactors: "custom"
     factorStartRateLimitSeconds: "3"

--- a/tests/cypress/fixtures/mfa-configuration/disabled.yml
+++ b/tests/cypress/fixtures/mfa-configuration/disabled.yml
@@ -1,7 +1,0 @@
-# Configuration used to disable MFA, handy as a post-test execution step
-- editConfiguration: "org.jahia.modules.upa.mfa"
-  properties:
-    enabled: "false"
-    # the login URL is not relevant when MFA is disabled
-    loginUrl: ""
-    enabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/email-template.yml
+++ b/tests/cypress/fixtures/mfa-configuration/email-template.yml
@@ -1,5 +1,4 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/email-template/myLoginPage.html"
     enabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/fake.yml
+++ b/tests/cypress/fixtures/mfa-configuration/fake.yml
@@ -2,7 +2,6 @@
 # but it's only used for testing GraphQL endpoints where no UI is tested
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/fake/fakePage.html"
     enabledFactors: "email_code"
     factorStartRateLimitSeconds: "3"

--- a/tests/cypress/fixtures/mfa-configuration/full-update-site.yml
+++ b/tests/cypress/fixtures/mfa-configuration/full-update-site.yml
@@ -1,5 +1,4 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/full-update-site/myLoginPage.html"
     enabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/multi-language-site-czech.yml
+++ b/tests/cypress/fixtures/mfa-configuration/multi-language-site-czech.yml
@@ -1,5 +1,4 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/cs/sites/multi-language-site/myLoginPage.html"
     enabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/multi-language-site-default.yml
+++ b/tests/cypress/fixtures/mfa-configuration/multi-language-site-default.yml
@@ -1,5 +1,4 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/multi-language-site/myLoginPage.html"
     enabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/partial-update-site.yml
+++ b/tests/cypress/fixtures/mfa-configuration/partial-update-site.yml
@@ -1,5 +1,4 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/partial-update-site/myLoginPage.html"
     enabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/quick-locking.yml
+++ b/tests/cypress/fixtures/mfa-configuration/quick-locking.yml
@@ -1,7 +1,6 @@
 # Used to test the locking mechanism with low numbers
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/fake/fakePage.html"
     enabledFactors: "email_code"
     maxAuthFailuresBeforeLock: "3"

--- a/tests/cypress/fixtures/mfa-configuration/sample-ui-long-suspension.yml
+++ b/tests/cypress/fixtures/mfa-configuration/sample-ui-long-suspension.yml
@@ -1,6 +1,5 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/sample-ui/myLoginPage.html"
     enabledFactors: "email_code"
     factorStartRateLimitSeconds: "3"

--- a/tests/cypress/fixtures/mfa-configuration/sample-ui-no-factors.yml
+++ b/tests/cypress/fixtures/mfa-configuration/sample-ui-no-factors.yml
@@ -1,6 +1,5 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/sample-ui/myLoginPage.html"
     enabledFactors: ""
     factorStartRateLimitSeconds: "0"

--- a/tests/cypress/fixtures/mfa-configuration/sample-ui.yml
+++ b/tests/cypress/fixtures/mfa-configuration/sample-ui.yml
@@ -1,6 +1,5 @@
 - editConfiguration: "org.jahia.modules.upa.mfa"
   properties:
-    enabled: "true"
     loginUrl: "/sites/sample-ui/myLoginPage.html"
     enabledFactors: "email_code"
     factorStartRateLimitSeconds: "3"


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/48.

### Description

Remove the `enabled` flag from the module configuration, as there is no longer a valid use case for it.
To disable the module, it can simply be stopped.
And to disable the second factors, the `enabledFactors` parameter has be set to an empty array.

See https://github.com/Jahia/user-password-authentication/issues/48#issuecomment-3717821350 for context.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
