### PR TITLE
chore: Rename module configuration from MFA to UPA

### DIFF
--- a/api/src/main/java/org/jahia/modules/upa/impl/MfaConfigurationService.java
+++ b/api/src/main/java/org/jahia/modules/upa/impl/MfaConfigurationService.java
@@ -21,7 +21,7 @@
  *
  * ==========================================================================================
  */
-package org.jahia.modules.upa.mfa.impl;
+package org.jahia.modules.upa.impl;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * Internal configuration service for the MFA module.
  * This is an implementation detail and is not meant to be used outside of this module (hence, not exported).
  */
-@Component(configurationPid = "org.jahia.modules.upa.mfa", service = MfaConfigurationService.class, immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Component(configurationPid = "org.jahia.modules.upa", service = MfaConfigurationService.class, immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
 @Designate(ocd = MfaConfigurationService.Config.class)
 public class MfaConfigurationService {
     private static final Logger logger = LoggerFactory.getLogger(MfaConfigurationService.class);
@@ -48,36 +48,36 @@ public class MfaConfigurationService {
         @AttributeDefinition(name = "%loginUrl", description = "%loginUrlDesc")
         String loginUrl();
 
-        @AttributeDefinition(name = "%enabledFactors", description = "%enabledFactorsDesc")
-        String[] enabledFactors() default {"email_code"};
+        @AttributeDefinition(name = "%mfaEnabledFactors", description = "%mfaEnabledFactorsDesc")
+        String[] mfaEnabledFactors() default {"email_code"};
 
         @AttributeDefinition(
-                name = "%maxAuthFailuresBeforeLock",
-                description = "%maxAuthFailuresBeforeLockDesc",
+                name = "%mfaMaxAuthFailuresBeforeLock",
+                description = "%mfaMaxAuthFailuresBeforeLockDesc",
                 defaultValue = "5"
         )
-        int maxAuthFailuresBeforeLock();
+        int mfaMaxAuthFailuresBeforeLock();
 
         @AttributeDefinition(
-                name = "%authFailuresWindowSeconds",
-                description = "%authFailuresWindowSecondsDesc",
+                name = "%mfaAuthFailuresWindowSeconds",
+                description = "%mfaAuthFailuresWindowSecondsDesc",
                 defaultValue = "120"
         )
-        int authFailuresWindowSeconds();
+        int mfaAuthFailuresWindowSeconds();
 
         @AttributeDefinition(
-                name = "%userTemporarySuspensionSeconds",
-                description = "%userTemporarySuspensionSecondsDesc",
+                name = "%mfaUserTemporarySuspensionSeconds",
+                description = "%mfaUserTemporarySuspensionSecondsDesc",
                 defaultValue = "600"
         )
-        int userTemporarySuspensionSeconds();
+        int mfaUserTemporarySuspensionSeconds();
 
         @AttributeDefinition(
-                name = "%factorStartRateLimitSeconds",
-                description = "%factorStartRateLimitSecondsDesc",
+                name = "%mfaFactorStartRateLimitSeconds",
+                description = "%mfaFactorStartRateLimitSecondsDesc",
                 defaultValue = "30"
         )
-        int factorStartRateLimitSeconds();
+        int mfaFactorStartRateLimitSeconds();
     }
 
     @Activate
@@ -96,24 +96,24 @@ public class MfaConfigurationService {
         return config.loginUrl();
     }
 
-    public String[] getEnabledFactors() {
-        return config.enabledFactors();
+    public String[] getMfaEnabledFactors() {
+        return config.mfaEnabledFactors();
     }
 
-    public int getMaxAuthFailuresBeforeLock() {
-        return config.maxAuthFailuresBeforeLock();
+    public int getMfaMaxAuthFailuresBeforeLock() {
+        return config.mfaMaxAuthFailuresBeforeLock();
     }
 
-    public int getAuthFailuresWindowSeconds() {
-        return config.authFailuresWindowSeconds();
+    public int getMfaAuthFailuresWindowSeconds() {
+        return config.mfaAuthFailuresWindowSeconds();
     }
 
-    public int getUserTemporarySuspensionSeconds() {
-        return config.userTemporarySuspensionSeconds();
+    public int getMfaUserTemporarySuspensionSeconds() {
+        return config.mfaUserTemporarySuspensionSeconds();
     }
 
-    public int getFactorStartRateLimitSeconds() {
-        return config.factorStartRateLimitSeconds();
+    public int getMfaFactorStartRateLimitSeconds() {
+        return config.mfaFactorStartRateLimitSeconds();
     }
 
 }

--- a/api/src/main/java/org/jahia/modules/upa/mfa/impl/MfaLoginUrlProvider.java
+++ b/api/src/main/java/org/jahia/modules/upa/mfa/impl/MfaLoginUrlProvider.java
@@ -1,5 +1,6 @@
 package org.jahia.modules.upa.mfa.impl;
 
+import org.jahia.modules.upa.impl.MfaConfigurationService;
 import org.jahia.params.valves.LoginUrlProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/api/src/main/resources/META-INF/configurations/org.jahia.modules.upa.mfa.cfg
+++ b/api/src/main/resources/META-INF/configurations/org.jahia.modules.upa.mfa.cfg
@@ -3,6 +3,6 @@
 loginUrl=/sites/systemSite/login.html
 enabledFactors.0=email_code
 maxAuthFailuresBeforeLock=5
-authFailuresWindowSeconds=120
-userTemporarySuspensionSeconds=600
-factorStartRateLimitSeconds=30
+mfaAuthFailuresWindowSeconds=120
+mfaUserTemporarySuspensionSeconds=600
+mfaFactorStartRateLimitSeconds=30

--- a/api/src/main/resources/OSGI-INF/l10n/mfa/config.properties
+++ b/api/src/main/resources/OSGI-INF/l10n/mfa/config.properties
@@ -1,14 +1,14 @@
-configName=Jahia MFA module configuration
-configDesc=Jahia MFA (Multi-Factor Authentication) module configuration. Once enabled and loginUrl configured, the module will display a login page that should contain some MFA login form components.
+configName=Jahia UPA module configuration
+configDesc=Jahia UPA (User Password Authentication) module configuration. Once 'loginUrl' is configured, the module will intercept unauthorized accesses and redirect the user to that URL so they can authenticate using an MFA flow.
 loginUrl=Url of the login page
 loginUrlDesc=Url of the login page that should contain some MFA login form components. (the page must be accessible without authentication)
-enabledFactors=Enabled Factors
-enabledFactorsDesc=Array of enabled MFA factor types. Use indexed properties like enabledFactors.0=email_code, enabledFactors.1=sms_code
-maxAuthFailuresBeforeLock=Max authentication failures before lock
-maxAuthFailuresBeforeLockDesc=Maximum number of failed MFA authentication attempts before user is locked
-authFailuresWindowSeconds=Authentication failures window (seconds)
-authFailuresWindowSecondsDesc=Time window in seconds for counting failed MFA authentication attempts
-userTemporarySuspensionSeconds=User temporary suspension duration (seconds)
-userTemporarySuspensionSecondsDesc=Duration in seconds for which a user is temporarily suspended after exceeding failed attempts
-factorStartRateLimitSeconds=Factor start rate limit (seconds)
-factorStartRateLimitSecondsDesc=Time to wait in second before a factor being started twice
+mfaEnabledFactors=Enabled Factors for MFA
+mfaEnabledFactorsDesc=Array of enabled MFA factor types. Use indexed properties like mfaEnabledFactors.0=email_code, mfaEnabledFactors.1=sms_code
+mfaMaxAuthFailuresBeforeLock=Max MFA authentication failures before lock
+mfaMaxAuthFailuresBeforeLockDesc=Maximum number of failed MFA authentication attempts before the user is locked
+mfaAuthFailuresWindowSeconds=Authentication failures window (seconds)
+mfaAuthFailuresWindowSecondsDesc=Time window in seconds for counting failed MFA authentication attempts
+mfaUserTemporarySuspensionSeconds=User temporary suspension duration (seconds)
+mfaUserTemporarySuspensionSecondsDesc=Duration in seconds for which a user is temporarily suspended after exceeding failed attempts in the MFA flow
+mfaFactorStartRateLimitSeconds=MFA factor start rate limit (seconds)
+mfaFactorStartRateLimitSecondsDesc=Time to wait in second before an MFAfactor being started twice

--- a/tests/cypress/e2e/graphQL.emailFactor.cy.ts
+++ b/tests/cypress/e2e/graphQL.emailFactor.cy.ts
@@ -165,7 +165,6 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
 
     it('Should throw an error when preparing without initiating the factor', () => {
         cy.log('2- prepare');
-        // Prepare('email_code', 'email_code', 'Failed to prepare factor: No active MFA session found');
         prepareEmailCodeFactorAndExpectGlobalError('no_active_session');
     });
 
@@ -179,9 +178,9 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
     it('Should be suspended when multiple wrong verification codes are entered in a row', () => {
         cy.log('0- installing the MFA configuration');
         // Config is:
-        // maxAuthFailuresBeforeLock: 3
-        // authFailuresWindowSeconds: 5
-        // userTemporarySuspensionSeconds: 6
+        // mfaMaxAuthFailuresBeforeLock: 3
+        // mfaAuthFailuresWindowSeconds: 5
+        // mfaUserTemporarySuspensionSeconds: 6
         installMFAConfig('quick-locking.yml');
 
         cy.log('1- initiate');
@@ -223,12 +222,12 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
         });
     });
 
-    it('Should be allowed to enter new code when an attempt is out of the authFailuresWindowSeconds', () => {
+    it('Should be allowed to enter new code when an attempt is out of the mfaAuthFailuresWindowSeconds', () => {
         cy.log('0- installing the MFA configuration');
         // Config is:
-        // maxAuthFailuresBeforeLock: 3
-        // authFailuresWindowSeconds: 5
-        // userTemporarySuspensionSeconds: 6
+        // mfaMaxAuthFailuresBeforeLock: 3
+        // mfaAuthFailuresWindowSeconds: 5
+        // mfaUserTemporarySuspensionSeconds: 6
         installMFAConfig('quick-locking.yml');
 
         cy.log('1- initiate');
@@ -258,7 +257,7 @@ describe('Tests for the GraphQL APIs related to the EmailCodeFactorProvider', ()
             verifyEmailCodeFactorAndExpectFactorError(wrongCode, 'verify.verification_failed', {
                 factorType: value => expect(value).to.eq('email_code')
             });
-            cy.log('wait until the first attempt is out of the authFailuresWindowSeconds');
+            cy.log('wait until the first attempt is out of the mfaAuthFailuresWindowSeconds');
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(3000);
             wrongCode = generateWrongCode(wrongCode);

--- a/tests/cypress/e2e/utils/i18n.ts
+++ b/tests/cypress/e2e/utils/i18n.ts
@@ -21,7 +21,7 @@ export const I18N = {
     locales: {
         en: {
             'unexpected_error': 'An unexpected error occurred',
-            'no_active_session': 'No active MFA session found',
+            'no_active_session': 'No active session found',
             'authentication_failed': 'Invalid username or password',
             'verification_failed': 'Verification failed',
             'suspended_user': 'Your account is temporarily locked for {{suspensionDurationInHours}} hour(s).',

--- a/tests/cypress/fixtures/mfa-configuration/custom-factor.yml
+++ b/tests/cypress/fixtures/mfa-configuration/custom-factor.yml
@@ -1,7 +1,7 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/sample-ui/myLoginPage.html"
-    enabledFactors: "custom"
-    factorStartRateLimitSeconds: "3"
-    maxAuthFailuresBeforeLock: "3"
-    userTemporarySuspensionSeconds: "5"
+    mfaEnabledFactors: "custom"
+    mfaFactorStartRateLimitSeconds: "3"
+    mfaMaxAuthFailuresBeforeLock: "3"
+    mfaUserTemporarySuspensionSeconds: "5"

--- a/tests/cypress/fixtures/mfa-configuration/email-template.yml
+++ b/tests/cypress/fixtures/mfa-configuration/email-template.yml
@@ -1,4 +1,4 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/email-template/myLoginPage.html"
-    enabledFactors: "email_code"
+    mfaEnabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/fake.yml
+++ b/tests/cypress/fixtures/mfa-configuration/fake.yml
@@ -1,9 +1,9 @@
 # Fake configuration where the login URL does not point at a valid page
 # but it's only used for testing GraphQL endpoints where no UI is tested
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/fake/fakePage.html"
-    enabledFactors: "email_code"
-    factorStartRateLimitSeconds: "3"
-    maxAuthFailuresBeforeLock: "3"
-    userTemporarySuspensionSeconds: "5"
+    mfaEnabledFactors: "email_code"
+    mfaFactorStartRateLimitSeconds: "3"
+    mfaMaxAuthFailuresBeforeLock: "3"
+    mfaUserTemporarySuspensionSeconds: "5"

--- a/tests/cypress/fixtures/mfa-configuration/full-update-site.yml
+++ b/tests/cypress/fixtures/mfa-configuration/full-update-site.yml
@@ -1,4 +1,4 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/full-update-site/myLoginPage.html"
-    enabledFactors: "email_code"
+    mfaEnabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/multi-language-site-czech.yml
+++ b/tests/cypress/fixtures/mfa-configuration/multi-language-site-czech.yml
@@ -1,4 +1,4 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/cs/sites/multi-language-site/myLoginPage.html"
-    enabledFactors: "email_code"
+    mfaEnabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/multi-language-site-default.yml
+++ b/tests/cypress/fixtures/mfa-configuration/multi-language-site-default.yml
@@ -1,4 +1,4 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/multi-language-site/myLoginPage.html"
-    enabledFactors: "email_code"
+    mfaEnabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/partial-update-site.yml
+++ b/tests/cypress/fixtures/mfa-configuration/partial-update-site.yml
@@ -1,4 +1,4 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/partial-update-site/myLoginPage.html"
-    enabledFactors: "email_code"
+    mfaEnabledFactors: "email_code"

--- a/tests/cypress/fixtures/mfa-configuration/quick-locking.yml
+++ b/tests/cypress/fixtures/mfa-configuration/quick-locking.yml
@@ -1,8 +1,8 @@
 # Used to test the locking mechanism with low numbers
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/fake/fakePage.html"
-    enabledFactors: "email_code"
-    maxAuthFailuresBeforeLock: "3"
-    authFailuresWindowSeconds: "5"
-    userTemporarySuspensionSeconds: "6"
+    mfaEnabledFactors: "email_code"
+    mfaMaxAuthFailuresBeforeLock: "3"
+    mfaAuthFailuresWindowSeconds: "5"
+    mfaUserTemporarySuspensionSeconds: "6"

--- a/tests/cypress/fixtures/mfa-configuration/sample-ui-long-suspension.yml
+++ b/tests/cypress/fixtures/mfa-configuration/sample-ui-long-suspension.yml
@@ -1,7 +1,7 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/sample-ui/myLoginPage.html"
-    enabledFactors: "email_code"
-    factorStartRateLimitSeconds: "3"
-    maxAuthFailuresBeforeLock: "3"
-    userTemporarySuspensionSeconds: "97200" # 27 hours = 60 * 60 * 27
+    mfaEnabledFactors: "email_code"
+    mfaFactorStartRateLimitSeconds: "3"
+    mfaMaxAuthFailuresBeforeLock: "3"
+    mfaUserTemporarySuspensionSeconds: "97200" # 27 hours = 60 * 60 * 27

--- a/tests/cypress/fixtures/mfa-configuration/sample-ui-no-factors.yml
+++ b/tests/cypress/fixtures/mfa-configuration/sample-ui-no-factors.yml
@@ -1,7 +1,7 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/sample-ui/myLoginPage.html"
-    enabledFactors: ""
-    factorStartRateLimitSeconds: "0"
-    maxAuthFailuresBeforeLock: "0"
-    userTemporarySuspensionSeconds: "0"
+    mfaEnabledFactors: ""
+    mfaFactorStartRateLimitSeconds: "0"
+    mfaMaxAuthFailuresBeforeLock: "0"
+    mfaUserTemporarySuspensionSeconds: "0"

--- a/tests/cypress/fixtures/mfa-configuration/sample-ui.yml
+++ b/tests/cypress/fixtures/mfa-configuration/sample-ui.yml
@@ -1,7 +1,7 @@
-- editConfiguration: "org.jahia.modules.upa.mfa"
+- editConfiguration: "org.jahia.modules.upa"
   properties:
     loginUrl: "/sites/sample-ui/myLoginPage.html"
-    enabledFactors: "email_code"
-    factorStartRateLimitSeconds: "3"
-    maxAuthFailuresBeforeLock: "3"
-    userTemporarySuspensionSeconds: "5"
+    mfaEnabledFactors: "email_code"
+    mfaFactorStartRateLimitSeconds: "3"
+    mfaMaxAuthFailuresBeforeLock: "3"
+    mfaUserTemporarySuspensionSeconds: "5"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-password-authentication-ui",
-  "description": "JavaScript module for MFA UI part of the User Password Authentication (UPA) module.",
+  "description": "JavaScript module providing the user interface for the User Password Authentication (UPA) module.",
   "version": "0.1.0-SNAPSHOT",
   "type": "module",
   "files": [

--- a/ui/settings/locales/en.json
+++ b/ui/settings/locales/en.json
@@ -1,6 +1,6 @@
 {
   "unexpected_error": "An unexpected error occurred",
-  "no_active_session": "No active MFA session found",
+  "no_active_session": "No active session found",
   "authentication_failed": "Invalid username or password",
   "verification_failed": "Verification failed",
   "suspended_user": "Your account is temporarily locked for {{suspensionDurationInHours}} hour(s).",


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/48.
### Description
Rename the module configuration from MFA to UPA and prefix the MFA-specific parameters with `mfa`.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
