### PR TITLE
ci: Pass correct Git ref to the manual run workflow

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -25,3 +25,4 @@ jobs:
       pagerduty_skip_notification: true
       provisioning_manifest: ${{ github.event.inputs.manifest }}
       artifact_prefix: upa
+      module_branch: ${{ github.ref }}


### PR DESCRIPTION
### Description
Without specifying the `module_branch` parameter, `master` is used by default causing this job to fail.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
