### PR TITLE
test: Resolve flaky MFA flow restart test by removing unnecessary delay

### DIFF
--- a/tests/cypress/e2e/ui.mfa.cy.ts
+++ b/tests/cypress/e2e/ui.mfa.cy.ts
@@ -493,8 +493,6 @@ describe('Tests for the UI module', () => {
         LoginStep.selectEmailCodeFactor();
 
         getVerificationCode(email).then(firstCode => {
-            // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.wait(1000);
             deleteAllEmails();
 
             // Re-start the flow from the beginning
@@ -504,8 +502,7 @@ describe('Tests for the UI module', () => {
 
             // User is still rate-limited even when re-starting the flow
             // Note: time left can vary depending on execution speed, so we check only the pattern here
-            //       deducting 1 second used for the wait above
-            const timeLeft = '[' + Array.from({length: (TIME_BEFORE_NEXT_CODE_MS / 1000) - 1}, (_, i) => i + 1).join(',') + ']';
+            const timeLeft = '[1-' + (TIME_BEFORE_NEXT_CODE_MS / 1000) + ']';
             EmailFactorStep.assertErrorMessage(new RegExp(
                 I18N_LOCALES['prepare.rate_limit_exceeded']
                     .replace('{{factorType}}', FACTOR_TYPE)
@@ -513,9 +510,8 @@ describe('Tests for the UI module', () => {
                     .replace('{{nextRetryInSeconds}}', timeLeft)
             ));
 
-            // Wait for the rate-limit to expire
             // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.wait(2000);
+            cy.wait(TIME_BEFORE_NEXT_CODE_MS); // Wait for the rate-limit to expire
 
             // Re-start the flow from the beginning
             LoginStep.triggerRedirect(SITE_KEY);


### PR DESCRIPTION
Fixes https://github.com/Jahia/user-password-authentication/issues/110.
### Description
Reduce chances of flakiness in the MFA flow test by getting rid of an unnecessary `cy.wait(...)`.

What _I think_ was happening:
1. after getting the verification code by email, there was a wait of **1 second**
2. then deleting the emails + restarting the flow (`triggerRedirect()`, `login()` and `selectEmailCodeFactor()`) could take **more than 2 seconds** (especially in CI)
3. if 2. was taking more than 2 seconds, that would give **more than 3 seconds** in total => in this case, the 3-second rate limit had expired and no error message was displayed.

#### Known limitation
While this fix significantly improves test stability, there's still a theoretical edge case: if the navigation + login + selectEmailCodeFactor sequence takes **more than 3 seconds** (very slow CI or network issues), the rate limit could expire and no error message would appear, causing the test to fail. However, this is much less likely now that the artificial 1-second wait has been removed.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
