### PR TITLE
build: Remove SNAPSHOT deps prior to release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.3.0-SNAPSHOT</version> <!-- should match ${jahia-bom.version} -->
+        <version>8.2.3.0</version> <!-- should match ${jahia-bom.version} -->
     </parent>
     <artifactId>user-password-authentication</artifactId>
     <name>UPA - root</name>
@@ -45,7 +45,7 @@
     </modules>
 
     <properties>
-        <jahia-bom.version>8.2.3.0-SNAPSHOT</jahia-bom.version> <!-- should match ${project.parent.version} -->
+        <jahia-bom.version>8.2.3.0</jahia-bom.version> <!-- should match ${project.parent.version} -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/118.

### Description
To release, there shouldn't be any SNAPSHOT dependencies:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3-jahia1:prepare (default-cli) on project user-password-authentication: Can't release project due to non released dependencies :
Error:      org.jahia.modules:jahia-modules:pom:8.2.3.0-SNAPSHOT
Error:      org.jahia.server:jahia-impl:jar:8.2.3.0-SNAPSHOT:provided
Error:      org.jahia.server:jahia-taglib:jar:8.2.3.0-SNAPSHOT:provided
Error:  in project 'UPA - root' (org.jahia.modules:user-password-authentication:pom:0.1.0-SNAPSHOT)
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error: Process completed with exit code 1.
```
See https://github.com/Jahia/user-password-authentication/actions/runs/21470877342/job/61842878627 for details.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
