### PR TITLE
ci: Include package.json in files to commit on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
                         <artifactId>maven-scm-plugin</artifactId>
                         <configuration>
                             <includes>
-                               ui/yarn.lock
+                               ui/yarn.lock,ui/package.json
                             </includes>
                             <message>chore(release): Prepare release ${project.version}</message>
                         </configuration>


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/118.

### Description

Also include the `package.json` in the list of files to commit during the release preparation phase.
Somehow it's working in the javascript-modules without being explicitly set (https://github.com/Jahia/javascript-modules/blob/main/pom.xml#L417)...
But it is listed for Luxe: https://github.com/Jahia/luxe-jahia-demo/blob/main/pom.xml#L127

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
