### PR TITLE
chore: Set groupId for UI JavaScript module

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -58,17 +58,7 @@
   "jahia": {
     "name": "UPA - UI",
     "maven": {
-      "groupId": "org.jahia.modules.javascript",
-      "distributionManagement": {
-        "repository": {
-          "id": "jahia-releases",
-          "url": "https://devtools.jahia.com/nexus/content/repositories/jahia-releases"
-        },
-        "snapshotRepository": {
-          "id": "jahia-snapshots",
-          "url": "https://devtools.jahia.com/nexus/content/repositories/jahia-snapshots"
-        }
-      }
+      "groupId": "org.jahia.modules.javascript"
     },
     "module-dependencies": "default,user-password-authentication-api",
     "module-type": "module",

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -23,6 +23,7 @@
         <groupId>org.jahia.modules</groupId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
+    <groupId>org.jahia.modules.javascript</groupId>
     <artifactId>user-password-authentication-ui</artifactId>
     <name>UPA - UI</name>
     <packaging>pom</packaging> <!-- the JavaScript .tgz module is generated, but for Maven it is just a pom -->


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/118.
### Description
Set the `groupId` for the UI module so it does not use [the default value ("org.example.javascript")](https://github.com/Jahia/javascript-modules/blob/2f8dc5f830de4d6c0e57acaf3fa73765c6e6eaad/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java#L237C78-L237C102).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
