### PR TITLE
ci: Prevent CI workflow to be triggered during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,8 @@
                             <includes>
                                ui/yarn.lock,ui/package.json
                             </includes>
-                            <message>chore(release): Prepare release ${project.version}</message>
+                            <!-- import to use "skip ci" to prevent the "on merge to main" workflow to be triggered halfway during the release process -->
+                            <message>chore(release): Prepare release ${project.version} [skip ci]</message>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Closes https://github.com/Jahia/user-password-authentication/issues/118.
### Description

When bumping the `version` field in the `package.json` as part of the release process, use `[skip ci]` in the commit message to ensure there is no workflow triggered when that commit is pushed to main.
Without it, there is a race condition with the https://github.com/Jahia/user-password-authentication/actions/workflows/on-merge.yml workflow causing the user-password-authentication-ui module to be deployed with the version `0.1.8` in its `pom.xml` but `0.2.0-SNAPSHOT` in its `package.json`.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
