### PR TITLE
fix: added a minimum Jahia version, set to 8.2.3.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -62,6 +62,7 @@
     },
     "module-dependencies": "default,user-password-authentication-api",
     "module-type": "module",
+    "required-version": "8.2.3.0",
     "server": "dist/server/index.js",
     "static-resources": "/dist/client,/dist/assets,/locales,/images,/icons"
   }


### PR DESCRIPTION
### Description
When trying to upload the module to the store, I got this error:

<img width="1151" height="1379" alt="Screenshot 2026-02-05 at 15 21 06" src="https://github.com/user-attachments/assets/d27035a2-2bc7-43c4-bcf1-db1a373da22d" />

After checking with @fbourasse it seems that we're missing the required version:

```
org.json.JSONException: JSONObject["required-version"] not found.
```

Likely because the Store UI does display the minimal Jahia version.


This PR set the version.