### PR TITLE
ci: Fix mvn URL of UI module in provisioning file

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -9,7 +9,7 @@
     - 'mvn:org.jahia.test/user-password-authentication-mfa-custom-factor-test-module'
     - 'mvn:org.jahia.test/user-password-authentication-mfa-custom-email-code-template-test-module'
     # LATEST is a Maven special "metaversion" that will always point to the latest version of the module, including snapshots
-    - 'js:mvn:org.jahia.modules/user-password-authentication-ui/LATEST/tgz'
+    - 'js:mvn:org.jahia.modules.javascript/user-password-authentication-ui/LATEST/tgz'
   autoStart: true
   uninstallPreviousVersion: true
 - include: 'provisioning.yml'


### PR DESCRIPTION
Closes #141 #118.

### Description
In https://github.com/Jahia/user-password-authentication/pull/135, the `groupId` of the UI module (a JavaScript module) has been set but the provisioning file did not get updated accordingly.

This is causing the nightly tests to fail as an outdated (and incorrect) version of the UI module is installed instead.
See https://github.com/Jahia/user-password-authentication/actions/runs/21808259863 for an example.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
