### PR TITLE
test: bump @jahia/cypress from 6.4.2 to 7.0.0

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,7 @@
     "@cypress/code-coverage": "^3.9.11",
     "@cypress/webpack-preprocessor": "^5.9.1",
     "@faker-js/faker": "^10.0.0",
-    "@jahia/cypress": "^6.4.2",
+    "@jahia/cypress": "^7.0.0",
     "@jahia/eslint-config": "^2.1.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -1036,10 +1036,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jahia/cypress@^6.4.2":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-6.4.2.tgz#494b9f5286e0dbf8eb6bac6bd662d8bb0558cb08"
-  integrity sha512-r/kOY44XKZda2l5XJ5ftjeO5B4iSf5q3azNEo4YgJjJCRv7Mf94wFAvPEgjxMQSrJvkr4t6oqovsObSE3pOwpA==
+"@jahia/cypress@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-7.0.0.tgz#d5d49e3077bf134bf8fbc6ca55fdb6270e09ab74"
+  integrity sha512-UW2Avv+B4QLp5VvXmGbZtpA4W7hNm10nREUU3V/J6KzJZDAHosxI76A0wlzm/hY/9GXGCvkhKMtw6eJrhybxsA==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"


### PR DESCRIPTION
This is needed to build with a more recent Cypress docker image.