### PR TITLE
fix: Improve page reload handling on auth flow restart

### DIFF
--- a/ui/src/components/Authentication/Authentication.client.tsx
+++ b/ui/src/components/Authentication/Authentication.client.tsx
@@ -31,13 +31,15 @@ export default function Authentication({
     redirect(content.contextPath);
   };
 
-  const resetFlow = () => {
+  const handleResetFlow = () => {
     setStep(Step.LOGIN);
     setFatalError(undefined);
-  }
+  };
   return (
     <ApiRootContext value={apiRoot}>
-      {step === Step.FATAL_ERROR && fatalError && <FatalErrorScreen error={fatalError} onResetFlow={() =>resetFlow()} />}
+      {step === Step.FATAL_ERROR && fatalError && (
+        <FatalErrorScreen error={fatalError} onResetFlow={() => handleResetFlow()} />
+      )}
       {step === Step.LOGIN && (
         <LoginForm
           content={content}

--- a/ui/src/components/Authentication/FatalErrorScreen.client.tsx
+++ b/ui/src/components/Authentication/FatalErrorScreen.client.tsx
@@ -13,17 +13,17 @@ interface FatalErrorScreenProps {
 }
 
 const suspendedUserErrorCode = "suspended_user";
-export default function FatalErrorScreen(props: Readonly<FatalErrorScreenProps>) {
+export default function FatalErrorScreen({ error, onResetFlow }: Readonly<FatalErrorScreenProps>) {
   const { t } = useTranslation();
   const [inProgress, setInProgress] = useState(false);
   const apiRoot = useApiRoot();
 
   // Compute error message from props without side effects
   const errorMessage = useMemo(() => {
-    if (props.error.code === suspendedUserErrorCode) {
+    if (error.code === suspendedUserErrorCode) {
       // special case for the suspension error message
       // Convert seconds to hours and round up for user-friendly display
-      const suspensionDurationInSecondsArg = props.error.arguments?.find(
+      const suspensionDurationInSecondsArg = error.arguments?.find(
         (arg) => arg.name === "suspensionDurationInSeconds",
       )?.value;
       const suspensionDurationInHours = suspensionDurationInSecondsArg
@@ -31,16 +31,16 @@ export default function FatalErrorScreen(props: Readonly<FatalErrorScreenProps>)
         : 0;
       return t(suspendedUserErrorCode, { suspensionDurationInHours });
     } else {
-      console.error("Unexpected error code:", props.error.code);
+      console.error("Unexpected error code:", error.code);
       return t(
-        props.error.code,
-        props.error.arguments?.reduce(
+        error.code,
+        error.arguments?.reduce(
           (acc, arg) => ({ ...acc, [arg.name]: arg.value }),
           {} as Record<string, string>,
         ),
       );
     }
-  }, [props.error]);
+  }, [error]);
 
   const [message, setMessage] = useState(errorMessage);
 
@@ -50,7 +50,7 @@ export default function FatalErrorScreen(props: Readonly<FatalErrorScreenProps>)
       .then((result) => {
         if (result.success) {
           setMessage("");
-          props.onResetFlow()
+          onResetFlow();
         } else {
           const { key, interpolation } = convertErrorArgsToInterpolation(result.error);
           setMessage(t(key, interpolation));


### PR DESCRIPTION
Fixes https://github.com/Jahia/user-password-authentication/issues/148.
### Description

Replace the hard page reload of the authentication screen with a React component state reset that resets the authentication flow to the login step.

### Context
Nightly tests were failing intermittently due to race conditions when `location.reload()` was called. The page reload wasn't predictable enough for tests to synchronize with the form visibility.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
