### PR TITLE
test: fix sporadic auth test failure and add log timestamps

### DIFF
--- a/tests/cypress/e2e/utils/auth.ts
+++ b/tests/cypress/e2e/utils/auth.ts
@@ -54,7 +54,7 @@ export const assertIsLoggedIn = (username: string) => {
         });
     }, {
         errorMsg: `Welcome message for ${username} not found`,
-        timeout: 10000,
+        timeout: 30000, // Sometimes, the welcome message takes time to appear
         interval: 1000
     });
     // Also ensure the user is not suspended

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -17,7 +17,9 @@
  */
 module.exports = (on, config) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    require('cypress-terminal-report/src/installLogsPrinter')(on);
+    require('cypress-terminal-report/src/installLogsPrinter')(on, {
+        printLogsToConsole: 'always' // Enable logs in both interactive and headless mode
+    });
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('@jahia/cypress/dist/plugins/registerPlugins').registerPlugins(on, config);
 

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -28,7 +28,25 @@ jsErrorsLogger.setAllowedJsWarnings([
 ]);
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-require('cypress-terminal-report/src/installLogsCollector')();
+require('cypress-terminal-report/src/installLogsCollector')({
+    processLog: log => {
+        const [logType, logMessage, severity] = log;
+        const timestamp = new Date().toISOString();
+        // Handle different types of log messages
+        let message;
+        if (Array.isArray(logMessage)) {
+            message = logMessage.join(' ');
+        } else if (typeof logMessage === 'object' && logMessage !== null) {
+            message = JSON.stringify(logMessage);
+        } else if (typeof logMessage === 'string') {
+            message = logMessage;
+        } else {
+            message = String(logMessage);
+        }
+
+        return [logType, `[${timestamp}] ${message}`, severity];
+    }
+});
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('@jahia/cypress/dist/support/registerSupport').registerSupport();
 


### PR DESCRIPTION
Fixes https://github.com/Jahia/user-password-authentication/issues/147.

### Description
 Increase `assertIsLoggedIn()` timeout from 10s to 30s to handle slow dashboard rendering in CI. Enable timestamps in Cypress logs for better debugging of timing issues.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
