### PR TITLE
test: Fix redirects handling by using cy.waitUntil()

### DIFF
--- a/.chachalog/-oCVCusV.md
+++ b/.chachalog/-oCVCusV.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-user-password-authentication: patch
----
-
-Use cy.waitUntil for redirect (#160)


### PR DESCRIPTION
Fixes https://github.com/Jahia/user-password-authentication/issues/147.
### Description
Using `cy.url()` with the redirect seems to cause sporadic issues in the test.
Replace it by a `cy.waitUntil()`.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
