### PR TITLE
fix: Flush HTML cache on login URL change

### DIFF
--- a/.chachalog/Hu0DXLtu.md
+++ b/.chachalog/Hu0DXLtu.md
@@ -1,0 +1,8 @@
+---
+# Allowed version bumps: patch, minor, major
+user-password-authentication: patch
+---
+
+Enable automatic cache flushing when updating the login URL in the Jahia UPA module (#162)
+
+When you update the `loginUrl` in the Jahia UPA module configuration, the system now automatically flushes the HTML output caches. This ensures that any pages previously rendered and cached using `org.jahia.services.render.URLGenerator.getLogin()` will immediately reflect the new login URL, preventing users from seeing outdated login pages.

--- a/.chachalog/V36TTB7D.md
+++ b/.chachalog/V36TTB7D.md
@@ -1,0 +1,8 @@
+---
+# Allowed version bumps: patch, minor, major
+user-password-authentication: patch
+---
+
+Set default login URL to empty in the Jahia UPA module configuration (#162)
+
+By default, the `loginUrl` setting is now empty when the module is installed. This means its `LoginUrlProvider` is disabled by default, ensuring that existing installations are not affected by unexpected login redirections. To enable the custom login redirection, specify your desired login page URL in the configuration.

--- a/api/src/main/java/org/jahia/modules/upa/impl/MfaConfigurationService.java
+++ b/api/src/main/java/org/jahia/modules/upa/impl/MfaConfigurationService.java
@@ -23,6 +23,8 @@
  */
 package org.jahia.modules.upa.impl;
 
+import org.apache.commons.lang3.StringUtils;
+import org.jahia.services.cache.CacheHelper;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -88,6 +90,11 @@ public class MfaConfigurationService {
 
     @Modified
     public void modified(Config config) {
+        if (!StringUtils.equals(config.loginUrl(), this.config.loginUrl())) {
+            // a new login URL has been set, the cache must be invalidated
+            // as org.jahia.services.render.URLGenerator.getLogin() may have been used to render some pages
+            CacheHelper.flushOutputCaches(true);
+        }
         this.config = config;
         logger.info("MFA Service configuration modified");
     }

--- a/api/src/main/java/org/jahia/modules/upa/mfa/impl/MfaLoginUrlProvider.java
+++ b/api/src/main/java/org/jahia/modules/upa/mfa/impl/MfaLoginUrlProvider.java
@@ -28,8 +28,6 @@ public class MfaLoginUrlProvider implements LoginUrlProvider {
 
     @Override
     public boolean hasCustomLoginUrl() {
-        // to be registered, the LoginUrlProvider must return true here
-        // this has been improved in https://github.com/Jahia/jahia-private/pull/4240, but is not available in Jahia 8.2.1.0 (the target Jahia version of this module)
         return true;
     }
 }

--- a/api/src/main/resources/META-INF/configurations/org.jahia.modules.upa.cfg
+++ b/api/src/main/resources/META-INF/configurations/org.jahia.modules.upa.cfg
@@ -1,6 +1,7 @@
 # default configuration, can be edited
 
-loginUrl=/sites/systemSite/login.html
+# Leave it empty so it's disabled by default. Example of URL: /sites/mySite/login.html
+loginUrl=
 enabledFactors.0=email_code
 maxAuthFailuresBeforeLock=5
 mfaAuthFailuresWindowSeconds=120

--- a/api/src/main/resources/OSGI-INF/l10n/mfa/config.properties
+++ b/api/src/main/resources/OSGI-INF/l10n/mfa/config.properties
@@ -1,7 +1,7 @@
 configName=Jahia UPA module configuration
 configDesc=Jahia UPA (User Password Authentication) module configuration. Once 'loginUrl' is configured, the module will intercept unauthorized accesses and redirect the user to that URL so they can authenticate using an MFA flow.
 loginUrl=Url of the login page
-loginUrlDesc=Url of the login page that should contain some MFA login form components. (the page must be accessible without authentication)
+loginUrlDesc=Url of the login page to redirect unauthenticated users to (ex: /sites/mySite/login.html). The page must be accessible without authentication. IMPORTANT: The HTML output caches will be flushed if you change this value!
 mfaEnabledFactors=Enabled Factors for MFA
 mfaEnabledFactorsDesc=Array of enabled MFA factor types. Use indexed properties like mfaEnabledFactors.0=email_code, mfaEnabledFactors.1=sms_code
 mfaMaxAuthFailuresBeforeLock=Max MFA authentication failures before lock


### PR DESCRIPTION
Fixes https://github.com/Jahia/user-password-authentication/issues/163.
### Description
- Flush output (HTML) cache when the login URL changes
- by default, use an empty `loginUrl` so that installing the UPA - API module does not impact the existing login mechanism until that URL gets manually defined

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
